### PR TITLE
Updated DeactivateAt and DeprovisionAt to use unix timestamps instead of a string formatted date

### DIFF
--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -38,7 +38,7 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 			EndpointId:   cmd.Flag("endpoint-id").Value.String(),
 			Chain:        cmd.Flag("chain").Value.String(),
 			Network:      cmd.Flag("network").Value.String(),
-			DeactivateAt: time.Now().Format(time.RFC3339),
+			DeactivateAt: time.Now().Unix(),
 		}
 
 		// Check that it is protected by basic auth

--- a/cmd/deprovision.go
+++ b/cmd/deprovision.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2023 QuickNode, Inc.
-
 */
 package cmd
 
@@ -39,7 +38,7 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 			EndpointId:    cmd.Flag("endpoint-id").Value.String(),
 			Chain:         cmd.Flag("chain").Value.String(),
 			Network:       cmd.Flag("network").Value.String(),
-			DeprovisionAt: time.Now().Format(time.RFC3339),
+			DeprovisionAt: time.Now().Unix(),
 		}
 
 		// Check that it is protected by basic auth

--- a/cmd/pudd.go
+++ b/cmd/pudd.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2023 QuickNode, Inc.
-
 */
 package cmd
 
@@ -170,7 +169,7 @@ The tool will use the base-url you pass to it and append these to the base URL t
 			EndpointId:   cmd.Flag("endpoint-id").Value.String(),
 			Chain:        cmd.Flag("chain").Value.String(),
 			Network:      cmd.Flag("network").Value.String(),
-			DeactivateAt: time.Now().Format(time.RFC3339),
+			DeactivateAt: time.Now().Unix(),
 		}
 
 		// Check that it is protected by basic auth
@@ -210,7 +209,7 @@ The tool will use the base-url you pass to it and append these to the base URL t
 			EndpointId:    cmd.Flag("endpoint-id").Value.String(),
 			Chain:         cmd.Flag("chain").Value.String(),
 			Network:       cmd.Flag("network").Value.String(),
-			DeprovisionAt: time.Now().Format(time.RFC3339),
+			DeprovisionAt: time.Now().Unix(),
 		}
 
 		// Check that it is protected by basic auth

--- a/marketplace/provisioning.go
+++ b/marketplace/provisioning.go
@@ -47,7 +47,7 @@ type DeactivateRequest struct {
 	EndpointId   string `json:"endpoint-id"`
 	Chain        string `json:"chain"`
 	Network      string `json:"network"`
-	DeactivateAt string `json:"deactivate-at"`
+	DeactivateAt int64  `json:"deactivate-at"`
 }
 
 type DeactivateResponse struct {
@@ -59,7 +59,7 @@ type DeprovisionRequest struct {
 	EndpointId    string `json:"endpoint-id"`
 	Chain         string `json:"chain"`
 	Network       string `json:"network"`
-	DeprovisionAt string `json:"deprovision-at"`
+	DeprovisionAt int64  `json:"deprovision-at"`
 }
 
 type DeprovisionResponse struct {


### PR DESCRIPTION
... to follow the guidelines from the guides and documentation:
https://www.quicknode.com/guides/quicknode-products/marketplace/how-provisioning-works-for-marketplace-partners/#deprovisioning