### PR TITLE
Add add-on-id and add-on-slug parameters to all marketplace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,31 @@ The `qn-marketplace-cli` has 4 different commands that allows you to test each o
 PROVISION:
 
 ```sh
-qn-marketplace-cli provision --url=http://localhost:3000/provision --basic-auth=q24rqaergser --chain=ethereum --network=mainnet --plan=your-plan-slug --quicknode-id=abcdef --endpoint-id=foobar --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/
+qn-marketplace-cli provision --url=http://localhost:3000/provision --basic-auth=q24rqaergser --chain=ethereum --network=mainnet --plan=your-plan-slug --quicknode-id=abcdef --endpoint-id=foobar --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
 UPDATE:
 
 ```sh
-qn-marketplace-cli update --url=http://localhost:3000/update --basic-auth=q24rqaergser --chain=ethereum --network=mainnet --plan=your-plan-slug --quicknode-id=abcdef --endpoint-id=foobar --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/
+qn-marketplace-cli update --url=http://localhost:3000/update --basic-auth=q24rqaergser --chain=ethereum --network=mainnet --plan=your-plan-slug --quicknode-id=abcdef --endpoint-id=foobar --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
 DEACTIVATE ENDPOINT:
 
 ```sh
-qn-marketplace-cli deactivate --url=http://localhost:3000/deactivate_endpoint --basic-auth=q24rqaergser --endpoint-id=foobar
+qn-marketplace-cli deactivate --url=http://localhost:3000/deactivate_endpoint --basic-auth=q24rqaergser --endpoint-id=foobar --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
 DEPROVISION:
 
 ```sh
-qn-marketplace-cli deprovision --url=http://localhost:3000/deprovision --basic-auth=q24rqaergser --quicknode-id=abcdef
+qn-marketplace-cli deprovision --url=http://localhost:3000/deprovision --basic-auth=q24rqaergser --quicknode-id=abcdef --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
 It also has one command that allows you to test all four actions at once:
 
 ```sh
-qn-marketplace-cli pudd --base-url=http://localhost:3000/ --basic-auth=q24rqaergser --chain=ethereum --network=mainnet --plan=your-plan-slug --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/
+qn-marketplace-cli pudd --base-url=http://localhost:3000/ --basic-auth=q24rqaergser --chain=ethereum --network=mainnet --plan=your-plan-slug --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
 ### JSON-RPC Testing
@@ -78,7 +78,7 @@ Please read [this guide](https://www.quicknode.com/guides/quicknode-products/mar
 If your add-on has RPC methods, the `qn-marketplace-cli` allows you to test your implementation by making some JSON-RPC calls to your application.
 
 ```sh
-qn-marketplace-cli rpc  --url=http://localhost:3000/rpc --method=your_addOnMethod --rpc-params='[9, "f"]' --chain=solana --network=mainnet --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/
+qn-marketplace-cli rpc  --url=http://localhost:3000/rpc --method=your_addOnMethod --rpc-params='[9, "f"]' --chain=solana --network=mainnet --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
 ## Development

--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2023 QuickNode, Inc.
-
 */
 package cmd
 
@@ -39,6 +38,8 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 			Chain:        cmd.Flag("chain").Value.String(),
 			Network:      cmd.Flag("network").Value.String(),
 			DeactivateAt: time.Now().Unix(),
+			AddOnId:      cmd.Flag("add-on-id").Value.String(),
+			AddOnSlug:    cmd.Flag("add-on-slug").Value.String(),
 		}
 
 		// Check that it is protected by basic auth
@@ -87,4 +88,6 @@ func init() {
 	deactivateCmd.PersistentFlags().StringP("endpoint-id", "e", uuid.NewV4().String(), "The endpoint ID to provision the add-on for (optional)")
 	deactivateCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	deactivateCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
+	deactivateCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	deactivateCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 }

--- a/cmd/deprovision.go
+++ b/cmd/deprovision.go
@@ -34,6 +34,8 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 
 		request := marketplace.DeprovisionRequest{
 			QuickNodeId: cmd.Flag("quicknode-id").Value.String(),
+			AddOnId:     cmd.Flag("add-on-id").Value.String(),
+			AddOnSlug:   cmd.Flag("add-on-slug").Value.String(),
 		}
 
 		// Check that it is protected by basic auth
@@ -79,4 +81,6 @@ func init() {
 	deprovisionCmd.PersistentFlags().String("basic-auth", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "The basic auth credentials for the add-on. Defaults to username = Aladdin and password = open sesame")
 
 	deprovisionCmd.PersistentFlags().StringP("quicknode-id", "q", uuid.NewV4().String(), "The QuickNode ID to provision the add-on for (optional)")
+	deprovisionCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	deprovisionCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 }

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -42,6 +42,8 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
 			Referers:          []string{"https://quicknode.com"},
 			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+			AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+			AddOnId:           cmd.Flag("add-on-id").Value.String(),
 		}
 
 		// Check that it is protected by basic auth
@@ -95,4 +97,6 @@ func init() {
 	provisionCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	provisionCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
 	provisionCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
+	provisionCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	provisionCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 }

--- a/cmd/pudd.go
+++ b/cmd/pudd.go
@@ -40,18 +40,20 @@ The tool will use the base-url you pass to it and append these to the base URL t
 			os.Exit(1)
 		}
 
-		// First Provision
-		request := marketplace.ProvisionRequest{
-			QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-			EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-			Chain:             cmd.Flag("chain").Value.String(),
-			Network:           cmd.Flag("network").Value.String(),
-			Plan:              cmd.Flag("plan").Value.String(),
-			WSSURL:            cmd.Flag("wss-url").Value.String(),
-			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-			Referers:          []string{"https://quicknode.com"},
-			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		}
+	// First Provision
+	request := marketplace.ProvisionRequest{
+		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
+		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
+		Chain:             cmd.Flag("chain").Value.String(),
+		Network:           cmd.Flag("network").Value.String(),
+		Plan:              cmd.Flag("plan").Value.String(),
+		WSSURL:            cmd.Flag("wss-url").Value.String(),
+		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+		Referers:          []string{"https://quicknode.com"},
+		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+		AddOnId:           cmd.Flag("add-on-id").Value.String(),
+	}
 
 		provisionUrl := baseUrl + "/provision"
 
@@ -117,17 +119,19 @@ The tool will use the base-url you pass to it and append these to the base URL t
 			color.Blue("\n\n→ PUT %s:\n", updateUrl)
 		}
 
-		updateRequest := marketplace.UpdateRequest{
-			QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-			EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-			Chain:             cmd.Flag("chain").Value.String(),
-			Network:           cmd.Flag("network").Value.String(),
-			Plan:              cmd.Flag("plan").Value.String(),
-			WSSURL:            cmd.Flag("wss-url").Value.String(),
-			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-			Referers:          []string{"https://quicknode.com"},
-			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		}
+	updateRequest := marketplace.UpdateRequest{
+		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
+		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
+		Chain:             cmd.Flag("chain").Value.String(),
+		Network:           cmd.Flag("network").Value.String(),
+		Plan:              cmd.Flag("plan").Value.String(),
+		WSSURL:            cmd.Flag("wss-url").Value.String(),
+		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+		Referers:          []string{"https://quicknode.com"},
+		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+		AddOnId:           cmd.Flag("add-on-id").Value.String(),
+	}
 
 		// Check that it is protected by basic auth
 		updateIsProtectedByBasicAuth, err := marketplace.RequiresBasicAuth(updateUrl, "PUT")
@@ -164,13 +168,15 @@ The tool will use the base-url you pass to it and append these to the base URL t
 		if verbose {
 			color.Blue("\n\n→ DELETE %s:\n", deactivateUrl)
 		}
-		deactivateRequest := marketplace.DeactivateRequest{
-			QuickNodeId:  cmd.Flag("quicknode-id").Value.String(),
-			EndpointId:   cmd.Flag("endpoint-id").Value.String(),
-			Chain:        cmd.Flag("chain").Value.String(),
-			Network:      cmd.Flag("network").Value.String(),
-			DeactivateAt: time.Now().Unix(),
-		}
+	deactivateRequest := marketplace.DeactivateRequest{
+		QuickNodeId:  cmd.Flag("quicknode-id").Value.String(),
+		EndpointId:   cmd.Flag("endpoint-id").Value.String(),
+		Chain:        cmd.Flag("chain").Value.String(),
+		Network:      cmd.Flag("network").Value.String(),
+		DeactivateAt: time.Now().Unix(),
+		AddOnId:      cmd.Flag("add-on-id").Value.String(),
+		AddOnSlug:    cmd.Flag("add-on-slug").Value.String(),
+	}
 
 		// Check that it is protected by basic auth
 		deactivateIsProtectedByBasicAuth, err := marketplace.RequiresBasicAuth(deactivateUrl, "DELETE")
@@ -202,11 +208,13 @@ The tool will use the base-url you pass to it and append these to the base URL t
 
 		color.Green("  ✓ Deactivate Endpoint was successful")
 
-		// Finally, deprovision
-		deprovisionUrl := baseUrl + "/deprovision"
-		deprovisionRequest := marketplace.DeprovisionRequest{
-			QuickNodeId: cmd.Flag("quicknode-id").Value.String(),
-		}
+	// Finally, deprovision
+	deprovisionUrl := baseUrl + "/deprovision"
+	deprovisionRequest := marketplace.DeprovisionRequest{
+		QuickNodeId: cmd.Flag("quicknode-id").Value.String(),
+		AddOnId:     cmd.Flag("add-on-id").Value.String(),
+		AddOnSlug:   cmd.Flag("add-on-slug").Value.String(),
+	}
 
 		// Check that it is protected by basic auth
 		deprovisionIsProtectedByBasicAuth, err := marketplace.RequiresBasicAuth(deprovisionUrl, "DELETE")
@@ -258,4 +266,6 @@ func init() {
 	puddCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	puddCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
 	puddCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
+	puddCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	puddCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 }

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -43,18 +43,20 @@ var restCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// First Provision
-		request := marketplace.ProvisionRequest{
-			QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-			EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-			Chain:             cmd.Flag("chain").Value.String(),
-			Network:           cmd.Flag("network").Value.String(),
-			Plan:              cmd.Flag("plan").Value.String(),
-			WSSURL:            cmd.Flag("wss-url").Value.String(),
-			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-			Referers:          []string{"https://quicknode.com"},
-			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		}
+	// First Provision
+	request := marketplace.ProvisionRequest{
+		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
+		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
+		Chain:             cmd.Flag("chain").Value.String(),
+		Network:           cmd.Flag("network").Value.String(),
+		Plan:              cmd.Flag("plan").Value.String(),
+		WSSURL:            cmd.Flag("wss-url").Value.String(),
+		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+		Referers:          []string{"https://quicknode.com"},
+		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+		AddOnId:           cmd.Flag("add-on-id").Value.String(),
+	}
 
 		if verbose {
 			color.Blue("→ POST %s:\n", provisionURL)
@@ -144,6 +146,8 @@ func init() {
 	restCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	restCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
 	restCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
+	restCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	restCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 
 	restCmd.PersistentFlags().String("rest-url", "", "The URL to make the REST calls to")
 	restCmd.PersistentFlags().String("rest-verb", "", "The REST HTTP Method or verb to use (e.g. GET or POST)")

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -43,18 +43,20 @@ var rpcCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// First Provision
-		request := marketplace.ProvisionRequest{
-			QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-			EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-			Chain:             cmd.Flag("chain").Value.String(),
-			Network:           cmd.Flag("network").Value.String(),
-			Plan:              cmd.Flag("plan").Value.String(),
-			WSSURL:            cmd.Flag("wss-url").Value.String(),
-			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-			Referers:          []string{"https://quicknode.com"},
-			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		}
+	// First Provision
+	request := marketplace.ProvisionRequest{
+		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
+		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
+		Chain:             cmd.Flag("chain").Value.String(),
+		Network:           cmd.Flag("network").Value.String(),
+		Plan:              cmd.Flag("plan").Value.String(),
+		WSSURL:            cmd.Flag("wss-url").Value.String(),
+		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+		Referers:          []string{"https://quicknode.com"},
+		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+		AddOnId:           cmd.Flag("add-on-id").Value.String(),
+	}
 
 		if verbose {
 			color.Blue("→ POST %s:\n", provisionURL)
@@ -174,6 +176,8 @@ func init() {
 	rpcCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	rpcCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
 	rpcCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
+	rpcCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	rpcCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 
 	rpcCmd.PersistentFlags().String("rpc-url", "", "The URL to make the RPC calls to")
 	rpcCmd.PersistentFlags().String("rpc-method", "", "The RPC Method to call")

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -37,17 +37,19 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 			os.Exit(1)
 		}
 
-		request := marketplace.ProvisionRequest{
-			QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-			EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-			Chain:             cmd.Flag("chain").Value.String(),
-			Network:           cmd.Flag("network").Value.String(),
-			Plan:              cmd.Flag("plan").Value.String(),
-			WSSURL:            cmd.Flag("wss-url").Value.String(),
-			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-			Referers:          []string{"https://quicknode.com"},
-			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		}
+	request := marketplace.ProvisionRequest{
+		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
+		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
+		Chain:             cmd.Flag("chain").Value.String(),
+		Network:           cmd.Flag("network").Value.String(),
+		Plan:              cmd.Flag("plan").Value.String(),
+		WSSURL:            cmd.Flag("wss-url").Value.String(),
+		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+		Referers:          []string{"https://quicknode.com"},
+		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+		AddOnId:           cmd.Flag("add-on-id").Value.String(),
+	}
 
 		if verbose {
 			color.Blue("→ POST %s:\n", provisionURL)
@@ -142,6 +144,8 @@ func init() {
 	ssoCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	ssoCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
 	ssoCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
+	ssoCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	ssoCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 
 	ssoCmd.PersistentFlags().StringP("jwt-secret", "j", "", "The JWT secret for the add-on")
 	ssoCmd.PersistentFlags().String("name", "", "The name of the user trying to SSO into the add-on")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -42,6 +42,8 @@ Learn more at https://www.quicknode.com/guides/quicknode-products/marketplace/ho
 			HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
 			Referers:          []string{"https://quicknode.com"},
 			ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+			AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+			AddOnId:           cmd.Flag("add-on-id").Value.String(),
 		}
 
 		// Check that it is protected by basic auth
@@ -93,4 +95,6 @@ func init() {
 	updateCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
 	updateCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
 	updateCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
+	updateCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
+	updateCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
 }

--- a/marketplace/provisioning.go
+++ b/marketplace/provisioning.go
@@ -18,6 +18,8 @@ type ProvisionRequest struct {
 	HTTPURL           string   `json:"http-url"`
 	Referers          []string `json:"referers"`
 	ContractAddresses []string `json:"contract_addresses"`
+	AddOnSlug         string   `json:"add-on-slug"`
+	AddOnId           string   `json:"add-on-id"`
 }
 
 type ProvisionResponse struct {
@@ -36,6 +38,8 @@ type UpdateRequest struct {
 	HTTPURL           string   `json:"http-url"`
 	Referers          []string `json:"referers"`
 	ContractAddresses []string `json:"contract_addresses"`
+	AddOnSlug         string   `json:"add-on-slug"`
+	AddOnId           string   `json:"add-on-id"`
 }
 
 type UpdateResponse struct {
@@ -48,6 +52,8 @@ type DeactivateRequest struct {
 	Chain        string `json:"chain"`
 	Network      string `json:"network"`
 	DeactivateAt int64  `json:"deactivate-at"`
+	AddOnId      string `json:"add-on-id"`
+	AddOnSlug    string `json:"add-on-slug"`
 }
 
 type DeactivateResponse struct {
@@ -56,6 +62,8 @@ type DeactivateResponse struct {
 
 type DeprovisionRequest struct {
 	QuickNodeId string `json:"quicknode-id"`
+	AddOnId     string `json:"add-on-id"`
+	AddOnSlug   string `json:"add-on-slug"`
 }
 
 type DeprovisionResponse struct {


### PR DESCRIPTION
We recently started sending `add-on-id` and `add-on-slug` in provisioning calls so that partners with multiple add-ons can identify which add-on they are receiving the requests for (in case they use the same infra/server for multiple add-ons). 

This PR updates the CLI to correctly send these two new additions:

- Add AddOnId and AddOnSlug fields to all request structs in marketplace/provisioning.go
- Add --add-on-id (-i) and --add-on-slug (-s) flags to all marketplace commands
- Update provision, update, deactivate, deprovision, pudd, rest, rpc, and sso commands
- Set default values of "33" for add-on-id and "myslug" for add-on-slug