### PR TITLE
Fix rest command crash on empty or non-JSON response body

### DIFF
--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -118,22 +118,25 @@ var restCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		printBody := func(b []byte) {
+			if len(b) == 0 {
+				return
+			}
+			var respBody interface{}
+			if jsonErr := json.Unmarshal(b, &respBody); jsonErr == nil {
+				responseJson, _ := json.MarshalIndent(respBody, "", "  ")
+				color.White("\n%s\n", responseJson)
+			} else {
+				color.White("\n%s\n", string(b))
+			}
+		}
+
 		if resp.StatusCode == 200 {
 			color.Green("  ✓ REST call was successful and returned:")
-			if len(body) > 0 {
-				var respBody interface{}
-				if jsonErr := json.Unmarshal(body, &respBody); jsonErr == nil {
-					responseJson, _ := json.MarshalIndent(respBody, "", "  ")
-					color.White("\n%s\n", responseJson)
-				} else {
-					color.White("\n%s\n", string(body))
-				}
-			}
+			printBody(body)
 		} else {
 			color.Red("  ✘ REST call failed:     %s\n\n", resp.Status)
-			if len(body) > 0 {
-				color.White("\n%s\n", string(body))
-			}
+			printBody(body)
 			os.Exit(1)
 		}
 	},

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -111,21 +112,28 @@ var restCmd = &cobra.Command{
 		}
 		defer resp.Body.Close()
 
-		// Decode the response body into an interface{} object
-		var respBody interface{}
-		err = json.NewDecoder(resp.Body).Decode(&respBody)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			color.Red("Error decoding JSON:", err)
+			color.Red("Error reading response body: %s", err)
 			os.Exit(1)
 		}
 
-		responseJson, _ := json.MarshalIndent(respBody, "", "  ")
 		if resp.StatusCode == 200 {
 			color.Green("  ✓ REST call was successful and returned:")
-			color.White("\n%s\n", responseJson)
+			if len(body) > 0 {
+				var respBody interface{}
+				if jsonErr := json.Unmarshal(body, &respBody); jsonErr == nil {
+					responseJson, _ := json.MarshalIndent(respBody, "", "  ")
+					color.White("\n%s\n", responseJson)
+				} else {
+					color.White("\n%s\n", string(body))
+				}
+			}
 		} else {
 			color.Red("  ✘ REST call failed:     %s\n\n", resp.Status)
-			color.White("\n%s\n", responseJson)
+			if len(body) > 0 {
+				color.White("\n%s\n", string(body))
+			}
 			os.Exit(1)
 		}
 	},


### PR DESCRIPTION
## Summary
- `rest` command previously called `json.NewDecoder` before checking the HTTP status, causing an `EOF` crash on empty response bodies and a confusing `invalid character '<'` error on HTML error pages
- Now reads the full body first via `io.ReadAll`, checks the status code, then JSON-decodes as best-effort (falls back to raw text if not valid JSON)

## Test Plan
- [ ] `GET` to an endpoint that returns an empty 200 body exits 0 and prints success
- [ ] A non-200 response with no body exits 1 and shows the HTTP status
- [ ] A non-200 response with an HTML body exits 1 and shows the raw body instead of a parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change to response handling in the marketplace test command; no auth, persistence, or production API surface affected.
> 
> **Overview**
> Fixes the **`rest`** CLI command so it no longer crashes or misreports failures when the HTTP response body is empty or not JSON.
> 
> The handler now **reads the full body** with `io.ReadAll` before interpreting it. A **`printBody`** helper skips empty bodies, **pretty-prints JSON when valid**, and otherwise **prints the raw text** (e.g. HTML error pages). Read failures use a clearer error message instead of treating them as JSON decode errors.
> 
> Success and non-200 paths both use the same body printing logic, so empty **200** responses can exit cleanly and failed calls show status plus whatever body was returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfe1727977c4f7d7bfa61d8b7b7eb980733d2c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->