### PR TITLE
DX-5324 - Add auth mode support to rpc and rest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ If your add-on has RPC methods, the `qn-marketplace-cli` allows you to test your
 qn-marketplace-cli rpc  --url=http://localhost:3000/rpc --method=your_addOnMethod --rpc-params='[9, "f"]' --chain=solana --network=mainnet --endpoint-url=https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --wss-url=wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/ --add-on-id 33 --add-on-slug your-addon-slug
 ```
 
+#### RPC and REST Auth Modes
+
+The `rpc` and `rest` commands support four auth modes, selected implicitly based on which flags are provided:
+
+| Mode | Trigger | Description |
+|------|---------|-------------|
+| Provisioning | `--url` is provided | Calls your provision endpoint first, then the RPC/REST URL |
+| Header auth | `--header` is provided | Forwards custom headers to the RPC/REST URL, skips provisioning |
+| Basic auth | `--basic-auth` is explicitly set (without `--url`) | Sends `Authorization: Basic <value>` to the RPC/REST URL |
+| No auth | None of the above flags | Calls the RPC/REST URL with no auth headers |
+
+**Header auth example:**
+```sh
+qn-marketplace-cli rpc --rpc-url=http://localhost:3000/rpc --rpc-method=your_addOnMethod --header "X-API-Key: secret" --header "X-Tenant: foo"
+```
+
+**Basic auth on the RPC endpoint directly (no provisioning):**
+```sh
+qn-marketplace-cli rpc --rpc-url=http://localhost:3000/rpc --rpc-method=your_addOnMethod --basic-auth dXNlcjpwYXNz
+```
+
+**No auth:**
+```sh
+qn-marketplace-cli rpc --rpc-url=http://localhost:3000/rpc --rpc-method=your_addOnMethod
+```
+
 ## Development
 
 `qn-marketplace-cli` is developed using [Go](https://go.dev/) and [Cobra](https://github.com/spf13/cobra) and released under an [MIT License](./LICENSE.txt).

--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type authMode int
+
+const (
+	authModeProvisioning authMode = iota
+	authModeHeader
+	authModeBasicAuth
+	authModeNone
+)
+
+// detectAuthMode returns the active auth mode based on which flags were provided.
+// Priority: provisioning > header > basic auth > none.
+func detectAuthMode(provisionURL string, customHeaders []string, basicAuthChanged bool) authMode {
+	switch {
+	case provisionURL != "":
+		return authModeProvisioning
+	case len(customHeaders) > 0:
+		return authModeHeader
+	case basicAuthChanged:
+		return authModeBasicAuth
+	default:
+		return authModeNone
+	}
+}
+
+// parseHeaders parses a slice of "Key: Value" strings into a map.
+// Malformed entries are skipped and returned as warning strings.
+func parseHeaders(headers []string) (map[string]string, []string) {
+	result := make(map[string]string)
+	var warnings []string
+	for _, h := range headers {
+		parts := strings.SplitN(h, ": ", 2)
+		if len(parts) != 2 {
+			warnings = append(warnings, fmt.Sprintf("skipping malformed header %q: expected \"Key: Value\" format", h))
+			continue
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, warnings
+}
+
+// applyAuthHeaders adds auth headers to req based on mode.
+// Returns any warnings from malformed --header values.
+func applyAuthHeaders(req *http.Request, mode authMode, customHeaders []string, basicAuth string) []string {
+	switch mode {
+	case authModeHeader:
+		parsed, warnings := parseHeaders(customHeaders)
+		for k, v := range parsed {
+			req.Header.Set(k, v)
+		}
+		return warnings
+	case authModeBasicAuth:
+		req.Header.Set("Authorization", "Basic "+basicAuth)
+	}
+	return nil
+}

--- a/cmd/headers_test.go
+++ b/cmd/headers_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestParseHeaders(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []string
+		wantHeaders  map[string]string
+		wantWarnings int
+	}{
+		{
+			name:        "valid single header",
+			input:       []string{"X-API-Key: secret"},
+			wantHeaders: map[string]string{"X-API-Key": "secret"},
+		},
+		{
+			name:        "valid multiple headers",
+			input:       []string{"X-API-Key: secret", "X-Tenant: foo"},
+			wantHeaders: map[string]string{"X-API-Key": "secret", "X-Tenant": "foo"},
+		},
+		{
+			name:        "value containing colon is preserved",
+			input:       []string{"Authorization: Bearer tok:en"},
+			wantHeaders: map[string]string{"Authorization": "Bearer tok:en"},
+		},
+		{
+			name:         "malformed header is skipped with warning",
+			input:        []string{"NoColonHere"},
+			wantHeaders:  map[string]string{},
+			wantWarnings: 1,
+		},
+		{
+			name:         "mixed valid and malformed",
+			input:        []string{"X-API-Key: secret", "BadHeader"},
+			wantHeaders:  map[string]string{"X-API-Key": "secret"},
+			wantWarnings: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, warns := parseHeaders(tt.input)
+			if len(warns) != tt.wantWarnings {
+				t.Errorf("parseHeaders() warnings = %d, want %d", len(warns), tt.wantWarnings)
+			}
+			for k, v := range tt.wantHeaders {
+				if got[k] != v {
+					t.Errorf("parseHeaders()[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectAuthMode(t *testing.T) {
+	tests := []struct {
+		name             string
+		provisionURL     string
+		customHeaders    []string
+		basicAuthChanged bool
+		want             authMode
+	}{
+		{"provisioning when url set", "http://localhost/provision", nil, false, authModeProvisioning},
+		{"header auth when headers set", "", []string{"X-API-Key: secret"}, false, authModeHeader},
+		{"basic auth when flag changed", "", nil, true, authModeBasicAuth},
+		{"no auth as default", "", nil, false, authModeNone},
+		{"provisioning takes priority over headers", "http://localhost/provision", []string{"X-Key: v"}, true, authModeProvisioning},
+		{"header takes priority over basic auth", "", []string{"X-Key: v"}, true, authModeHeader},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectAuthMode(tt.provisionURL, tt.customHeaders, tt.basicAuthChanged)
+			if got != tt.want {
+				t.Errorf("detectAuthMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyAuthHeaders(t *testing.T) {
+	t.Run("header mode sets custom headers", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		warns := applyAuthHeaders(req, authModeHeader, []string{"X-API-Key: secret"}, "")
+		if req.Header.Get("X-API-Key") != "secret" {
+			t.Errorf("expected X-API-Key: secret, got %q", req.Header.Get("X-API-Key"))
+		}
+		if len(warns) != 0 {
+			t.Errorf("expected no warnings, got %v", warns)
+		}
+	})
+
+	t.Run("basic auth mode sets Authorization header", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		applyAuthHeaders(req, authModeBasicAuth, nil, "dXNlcjpwYXNz")
+		if req.Header.Get("Authorization") != "Basic dXNlcjpwYXNz" {
+			t.Errorf("expected Basic auth header, got %q", req.Header.Get("Authorization"))
+		}
+	})
+
+	t.Run("no auth mode sets no extra headers", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		applyAuthHeaders(req, authModeNone, nil, "")
+		if req.Header.Get("Authorization") != "" {
+			t.Errorf("expected no Authorization header, got %q", req.Header.Get("Authorization"))
+		}
+	})
+
+	t.Run("provisioning mode sets no extra auth headers", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		applyAuthHeaders(req, authModeProvisioning, nil, "somevalue")
+		if req.Header.Get("Authorization") != "" {
+			t.Errorf("expected no Authorization header in provisioning mode, got %q", req.Header.Get("Authorization"))
+		}
+	})
+
+	t.Run("malformed header in header mode produces warning", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		warns := applyAuthHeaders(req, authModeHeader, []string{"BadHeader"}, "")
+		if len(warns) != 1 {
+			t.Errorf("expected 1 warning, got %d", len(warns))
+		}
+	})
+}

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// restCmd represents the rest command
 var restCmd = &cobra.Command{
 	Use:   "rest",
 	Short: "Allows you to test your add-on's REST paths",
@@ -26,11 +25,6 @@ var restCmd = &cobra.Command{
 		header := color.New(color.FgWhite, color.BgBlue).SprintFunc()
 		fmt.Printf("%s\n\n", header("        REST        "))
 		verbose := cmd.Flag("verbose").Value.String() == "true"
-		provisionURL := cmd.Flag("url").Value.String()
-		if provisionURL == "" {
-			fmt.Print("Please provide a URL for the provision API via the --url flag\n")
-			os.Exit(1)
-		}
 
 		restURL := cmd.Flag("rest-url").Value.String()
 		if restURL == "" {
@@ -44,66 +38,76 @@ var restCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-	// First Provision
-	request := marketplace.ProvisionRequest{
-		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-		Chain:             cmd.Flag("chain").Value.String(),
-		Network:           cmd.Flag("network").Value.String(),
-		Plan:              cmd.Flag("plan").Value.String(),
-		WSSURL:            cmd.Flag("wss-url").Value.String(),
-		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-		Referers:          []string{"https://quicknode.com"},
-		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
-		AddOnId:           cmd.Flag("add-on-id").Value.String(),
-	}
-
-		if verbose {
-			color.Blue("→ POST %s:\n", provisionURL)
-		}
-		requestJson, _ := json.MarshalIndent(request, "", "  ")
-		if verbose {
-			fmt.Printf("%s\n", requestJson)
-		}
-
-		provisionResponse, err := marketplace.Provision(provisionURL, request, cmd.Flag("basic-auth").Value.String())
+		provisionURL := cmd.Flag("url").Value.String()
+		customHeaders, err := cmd.Flags().GetStringArray("header")
 		if err != nil {
-			color.Red("%s", err)
+			color.Red("Error reading --header flag: %s", err)
 			os.Exit(1)
 		}
+		mode := detectAuthMode(provisionURL, customHeaders, cmd.Flag("basic-auth").Changed)
 
-		if verbose {
-			fmt.Printf("\nProvision was successful:\n")
-			fmt.Printf("  Status:     %s\n", provisionResponse.Status)
-			fmt.Printf("  Dashboard URL:     %s\n", provisionResponse.DashboardURL)
-			fmt.Printf("  Access URL:     %s\n\n", provisionResponse.AccessURL)
+		quicknodeID := cmd.Flag("quicknode-id").Value.String()
+		endpointID := cmd.Flag("endpoint-id").Value.String()
+
+		if mode == authModeProvisioning {
+			request := marketplace.ProvisionRequest{
+				QuickNodeId:       quicknodeID,
+				EndpointId:        endpointID,
+				Chain:             cmd.Flag("chain").Value.String(),
+				Network:           cmd.Flag("network").Value.String(),
+				Plan:              cmd.Flag("plan").Value.String(),
+				WSSURL:            cmd.Flag("wss-url").Value.String(),
+				HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+				Referers:          []string{"https://quicknode.com"},
+				ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+				AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+				AddOnId:           cmd.Flag("add-on-id").Value.String(),
+			}
+
+			if verbose {
+				color.Blue("→ POST %s:\n", provisionURL)
+				requestJson, _ := json.MarshalIndent(request, "", "  ")
+				fmt.Printf("%s\n", requestJson)
+			}
+
+			provisionResponse, err := marketplace.Provision(provisionURL, request, cmd.Flag("basic-auth").Value.String())
+			if err != nil {
+				color.Red("%s", err)
+				os.Exit(1)
+			}
+
+			if verbose {
+				fmt.Printf("\nProvision was successful:\n")
+				fmt.Printf("  Status:     %s\n", provisionResponse.Status)
+				fmt.Printf("  Dashboard URL:     %s\n", provisionResponse.DashboardURL)
+				fmt.Printf("  Access URL:     %s\n\n", provisionResponse.AccessURL)
+			}
 		}
 
-		// Now we can make the REST call
-		var requestBody = cmd.Flag("rest-body").Value.String()
+		requestBody := cmd.Flag("rest-body").Value.String()
 
-		// Create an HTTP request with the REST request
 		if verbose {
-			color.Blue("\n→ %s %s:\n", restVerb, cmd.Flag("rest-url").Value.String())
+			color.Blue("\n→ %s %s:\n", restVerb, restURL)
 			fmt.Printf("%s\n", requestBody)
 		}
 
-		httpReq, err := http.NewRequest(restVerb, cmd.Flag("rest-url").Value.String(), strings.NewReader(requestBody))
+		httpReq, err := http.NewRequest(restVerb, restURL, strings.NewReader(requestBody))
 		if err != nil {
 			color.Red("Error creating HTTP request: %s", err)
 			os.Exit(1)
 		}
 
-		// Set the HTTP request header to indicate that the request body is in JSON format
+		for _, w := range applyAuthHeaders(httpReq, mode, customHeaders, cmd.Flag("basic-auth").Value.String()) {
+			color.Yellow("Warning: %s\n", w)
+		}
+
 		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("X-QUICKNODE-ID", cmd.Flag("quicknode-id").Value.String())
-		httpReq.Header.Set("X-INSTANCE-ID", cmd.Flag("endpoint-id").Value.String())
+		httpReq.Header.Set("X-QUICKNODE-ID", quicknodeID)
+		httpReq.Header.Set("X-INSTANCE-ID", endpointID)
 		httpReq.Header.Set("X-QN-CHAIN", cmd.Flag("chain").Value.String())
 		httpReq.Header.Set("X-QN-NETWORK", cmd.Flag("network").Value.String())
 		httpReq.Header.Add("X-QN-TESTING", "true")
 
-		// Send the HTTP request and capture the response
 		client := http.Client{}
 		resp, err := client.Do(httpReq)
 		if err != nil {
@@ -145,22 +149,19 @@ var restCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(restCmd)
 
-	restCmd.PersistentFlags().StringP("url", "u", "", "The URL of the add-on's provision endpoint")
-
-	// Note: basic auth defaults to username = Aladdin and password = open sesame
-	restCmd.PersistentFlags().String("basic-auth", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "The basic auth credentials for the add-on. Defaults to username = Aladdin and password = open sesame")
-
-	restCmd.PersistentFlags().StringP("quicknode-id", "q", uuid.NewV4().String(), "The QuickNode ID to provision the add-on for (optional)")
-	restCmd.PersistentFlags().StringP("endpoint-id", "e", uuid.NewV4().String(), "The endpoint ID to provision the add-on for (optional)")
-	restCmd.PersistentFlags().StringP("endpoint-url", "l", "https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The endpoint URL to provision the add-on for (optional - defaults to an ethereum mainnet endpoint")
-	restCmd.PersistentFlags().StringP("wss-url", "w", "wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The WSS URL to provision the add-on for (optional - defaults to an ethereum mainnet endpoint")
-	restCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
-	restCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
-	restCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
-	restCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
-	restCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
-
+	restCmd.PersistentFlags().StringP("url", "u", "", "The URL of the add-on's provision endpoint (optional, enables provisioning mode)")
+	restCmd.PersistentFlags().String("basic-auth", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "The basic auth credentials for the add-on")
+	restCmd.PersistentFlags().StringP("quicknode-id", "q", uuid.NewV4().String(), "The QuickNode ID (optional)")
+	restCmd.PersistentFlags().StringP("endpoint-id", "e", uuid.NewV4().String(), "The endpoint ID (optional)")
+	restCmd.PersistentFlags().StringP("endpoint-url", "l", "https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The endpoint HTTP URL (optional)")
+	restCmd.PersistentFlags().StringP("wss-url", "w", "wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The endpoint WSS URL (optional)")
+	restCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain")
+	restCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network")
+	restCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan slug")
+	restCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The add-on ID")
+	restCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The add-on slug")
 	restCmd.PersistentFlags().String("rest-url", "", "The URL to make the REST calls to")
 	restCmd.PersistentFlags().String("rest-verb", "", "The REST HTTP Method or verb to use (e.g. GET or POST)")
-	restCmd.PersistentFlags().String("rest-body", "", "The Rest Request Body")
+	restCmd.PersistentFlags().String("rest-body", "", "The REST request body")
+	restCmd.PersistentFlags().StringArray("header", []string{}, "HTTP header in \"Key: Value\" format (repeatable, enables header auth mode)")
 }

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -109,7 +109,7 @@ var restCmd = &cobra.Command{
 		httpReq.Header.Set("X-INSTANCE-ID", endpointID)
 		httpReq.Header.Set("X-QN-CHAIN", cmd.Flag("chain").Value.String())
 		httpReq.Header.Set("X-QN-NETWORK", cmd.Flag("network").Value.String())
-		httpReq.Header.Add("X-QN-TESTING", "true")
+		httpReq.Header.Set("X-QN-TESTING", "true")
 
 		client := http.Client{}
 		resp, err := client.Do(httpReq)

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -45,6 +45,9 @@ var restCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		mode := detectAuthMode(provisionURL, customHeaders, cmd.Flag("basic-auth").Changed)
+		if mode == authModeProvisioning && len(customHeaders) > 0 {
+			color.Yellow("Warning: --header flags are ignored in provisioning mode\n")
+		}
 
 		quicknodeID := cmd.Flag("quicknode-id").Value.String()
 		endpointID := cmd.Flag("endpoint-id").Value.String()

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -44,6 +44,9 @@ var rpcCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		mode := detectAuthMode(provisionURL, customHeaders, cmd.Flag("basic-auth").Changed)
+		if mode == authModeProvisioning && len(customHeaders) > 0 {
+			color.Yellow("Warning: --header flags are ignored in provisioning mode\n")
+		}
 
 		quicknodeID := cmd.Flag("quicknode-id").Value.String()
 		endpointID := cmd.Flag("endpoint-id").Value.String()

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -38,7 +38,11 @@ var rpcCmd = &cobra.Command{
 		}
 
 		provisionURL := cmd.Flag("url").Value.String()
-		customHeaders, _ := cmd.Flags().GetStringArray("header")
+		customHeaders, err := cmd.Flags().GetStringArray("header")
+		if err != nil {
+			color.Red("Error reading --header flag: %s", err)
+			os.Exit(1)
+		}
 		mode := detectAuthMode(provisionURL, customHeaders, cmd.Flag("basic-auth").Changed)
 
 		quicknodeID := cmd.Flag("quicknode-id").Value.String()
@@ -113,16 +117,16 @@ var rpcCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		for _, w := range applyAuthHeaders(httpReq, mode, customHeaders, cmd.Flag("basic-auth").Value.String()) {
+			color.Yellow("Warning: %s\n", w)
+		}
+
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("X-QUICKNODE-ID", quicknodeID)
 		httpReq.Header.Set("X-INSTANCE-ID", endpointID)
 		httpReq.Header.Set("X-QN-CHAIN", cmd.Flag("chain").Value.String())
 		httpReq.Header.Set("X-QN-NETWORK", cmd.Flag("network").Value.String())
 		httpReq.Header.Add("X-QN-TESTING", "true")
-
-		for _, w := range applyAuthHeaders(httpReq, mode, customHeaders, cmd.Flag("basic-auth").Value.String()) {
-			color.Yellow("Warning: %s\n", w)
-		}
 
 		client := http.Client{}
 		resp, err := client.Do(httpReq)

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rpcCmd represents the rpc command
 var rpcCmd = &cobra.Command{
 	Use:   "rpc",
 	Short: "Allows you to test your add-on's RPC methods",
@@ -25,11 +24,6 @@ var rpcCmd = &cobra.Command{
 		header := color.New(color.FgWhite, color.BgBlue).SprintFunc()
 		fmt.Printf("%s\n\n", header("        RPC        "))
 		verbose := cmd.Flag("verbose").Value.String() == "true"
-		provisionURL := cmd.Flag("url").Value.String()
-		if provisionURL == "" {
-			fmt.Print("Please provide a URL for the provision API via the --url flag\n")
-			os.Exit(1)
-		}
 
 		rpcURL := cmd.Flag("rpc-url").Value.String()
 		if rpcURL == "" {
@@ -39,54 +33,55 @@ var rpcCmd = &cobra.Command{
 
 		rpcMethod := cmd.Flag("rpc-method").Value.String()
 		if rpcMethod == "" {
-			color.Red("Please provide an RPC Method for the provision API via the --rpc-method flag\n")
+			color.Red("Please provide an RPC Method via the --rpc-method flag\n")
 			os.Exit(1)
 		}
 
-	// First Provision
-	request := marketplace.ProvisionRequest{
-		QuickNodeId:       cmd.Flag("quicknode-id").Value.String(),
-		EndpointId:        cmd.Flag("endpoint-id").Value.String(),
-		Chain:             cmd.Flag("chain").Value.String(),
-		Network:           cmd.Flag("network").Value.String(),
-		Plan:              cmd.Flag("plan").Value.String(),
-		WSSURL:            cmd.Flag("wss-url").Value.String(),
-		HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
-		Referers:          []string{"https://quicknode.com"},
-		ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
-		AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
-		AddOnId:           cmd.Flag("add-on-id").Value.String(),
-	}
+		provisionURL := cmd.Flag("url").Value.String()
+		customHeaders, _ := cmd.Flags().GetStringArray("header")
+		mode := detectAuthMode(provisionURL, customHeaders, cmd.Flag("basic-auth").Changed)
 
-		if verbose {
-			color.Blue("→ POST %s:\n", provisionURL)
-		}
-		requestJson, _ := json.MarshalIndent(request, "", "  ")
-		if verbose {
-			fmt.Printf("%s\n", requestJson)
-		}
+		quicknodeID := cmd.Flag("quicknode-id").Value.String()
+		endpointID := cmd.Flag("endpoint-id").Value.String()
 
-		provisionResponse, err := marketplace.Provision(provisionURL, request, cmd.Flag("basic-auth").Value.String())
-		if err != nil {
-			color.Red("%s", err)
-			os.Exit(1)
-		}
+		if mode == authModeProvisioning {
+			request := marketplace.ProvisionRequest{
+				QuickNodeId:       quicknodeID,
+				EndpointId:        endpointID,
+				Chain:             cmd.Flag("chain").Value.String(),
+				Network:           cmd.Flag("network").Value.String(),
+				Plan:              cmd.Flag("plan").Value.String(),
+				WSSURL:            cmd.Flag("wss-url").Value.String(),
+				HTTPURL:           cmd.Flag("endpoint-url").Value.String(),
+				Referers:          []string{"https://quicknode.com"},
+				ContractAddresses: []string{"0x4d224452801ACEd8B2F0aebE155379bb5D594381"},
+				AddOnSlug:         cmd.Flag("add-on-slug").Value.String(),
+				AddOnId:           cmd.Flag("add-on-id").Value.String(),
+			}
 
-		if verbose {
-			fmt.Printf("\nProvision was successful:\n")
-			fmt.Printf("  Status:     %s\n", provisionResponse.Status)
-			fmt.Printf("  Dashboard URL:     %s\n", provisionResponse.DashboardURL)
-			fmt.Printf("  Access URL:     %s\n\n", provisionResponse.AccessURL)
-		}
+			if verbose {
+				color.Blue("→ POST %s:\n", provisionURL)
+				requestJson, _ := json.MarshalIndent(request, "", "  ")
+				fmt.Printf("%s\n", requestJson)
+			}
 
-		// Now we can make the RPC call
-		// First, Create an RPC request object
-		var params []interface{}
-		var paramsFlag = cmd.Flag("rpc-params").Value.String()
-
-		if paramsFlag != "" {
-			err := json.Unmarshal([]byte(paramsFlag), &params)
+			provisionResponse, err := marketplace.Provision(provisionURL, request, cmd.Flag("basic-auth").Value.String())
 			if err != nil {
+				color.Red("%s", err)
+				os.Exit(1)
+			}
+
+			if verbose {
+				fmt.Printf("\nProvision was successful:\n")
+				fmt.Printf("  Status:     %s\n", provisionResponse.Status)
+				fmt.Printf("  Dashboard URL:     %s\n", provisionResponse.DashboardURL)
+				fmt.Printf("  Access URL:     %s\n\n", provisionResponse.AccessURL)
+			}
+		}
+
+		var params []interface{}
+		if paramsFlag := cmd.Flag("rpc-params").Value.String(); paramsFlag != "" {
+			if err := json.Unmarshal([]byte(paramsFlag), &params); err != nil {
 				color.Red("Error parsing params: %s", err)
 				os.Exit(1)
 			}
@@ -95,44 +90,40 @@ var rpcCmd = &cobra.Command{
 		}
 
 		req := marketplace.RPCRequest{
-			Method: cmd.Flag("rpc-method").Value.String(),
+			Method: rpcMethod,
 			Params: params,
 			ID:     uuid.NewV4().String(),
 		}
 
-		// Encode the request object into a JSON string
 		reqBody, err := json.Marshal(req)
 		if err != nil {
-			color.Red("Error encoding JSON: %", err)
+			color.Red("Error encoding JSON: %s", err)
 			os.Exit(1)
 		}
 
-		reqBodyIndented, err := json.MarshalIndent(req, "", "  ")
-		if err != nil {
-			color.Red("Error encoding JSON: %", err)
-			os.Exit(1)
-		}
-		// Create an HTTP request with the JSON-RPC request body
 		if verbose {
-			color.Blue("\n→ POST %s:\n", cmd.Flag("rpc-url").Value.String())
+			reqBodyIndented, _ := json.MarshalIndent(req, "", "  ")
+			color.Blue("\n→ POST %s:\n", rpcURL)
 			fmt.Printf("%s\n", reqBodyIndented)
 		}
 
-		httpReq, err := http.NewRequest("POST", cmd.Flag("rpc-url").Value.String(), bytes.NewBuffer(reqBody))
+		httpReq, err := http.NewRequest("POST", rpcURL, bytes.NewBuffer(reqBody))
 		if err != nil {
 			color.Red("Error creating HTTP request: %s", err)
 			os.Exit(1)
 		}
 
-		// Set the HTTP request header to indicate that the request body is in JSON format
 		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("X-QUICKNODE-ID", cmd.Flag("quicknode-id").Value.String())
-		httpReq.Header.Set("X-INSTANCE-ID", cmd.Flag("endpoint-id").Value.String())
+		httpReq.Header.Set("X-QUICKNODE-ID", quicknodeID)
+		httpReq.Header.Set("X-INSTANCE-ID", endpointID)
 		httpReq.Header.Set("X-QN-CHAIN", cmd.Flag("chain").Value.String())
 		httpReq.Header.Set("X-QN-NETWORK", cmd.Flag("network").Value.String())
 		httpReq.Header.Add("X-QN-TESTING", "true")
 
-		// Send the HTTP request and capture the response
+		for _, w := range applyAuthHeaders(httpReq, mode, customHeaders, cmd.Flag("basic-auth").Value.String()) {
+			color.Yellow("Warning: %s\n", w)
+		}
+
 		client := http.Client{}
 		resp, err := client.Do(httpReq)
 		if err != nil {
@@ -141,11 +132,9 @@ var rpcCmd = &cobra.Command{
 		}
 		defer resp.Body.Close()
 
-		// Decode the response body into an interface{} object
 		var respBody interface{}
-		err = json.NewDecoder(resp.Body).Decode(&respBody)
-		if err != nil {
-			color.Red("Error decoding JSON:", err)
+		if err = json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+			color.Red("Error decoding JSON: %s", err)
 			os.Exit(1)
 		}
 
@@ -164,22 +153,19 @@ var rpcCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(rpcCmd)
 
-	rpcCmd.PersistentFlags().StringP("url", "u", "", "The URL of the add-on's provision endpoint")
-
-	// Note: basic auth defaults to username = Aladdin and password = open sesame
-	rpcCmd.PersistentFlags().String("basic-auth", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "The basic auth credentials for the add-on. Defaults to username = Aladdin and password = open sesame")
-
-	rpcCmd.PersistentFlags().StringP("quicknode-id", "q", uuid.NewV4().String(), "The QuickNode ID to provision the add-on for (optional)")
-	rpcCmd.PersistentFlags().StringP("endpoint-id", "e", uuid.NewV4().String(), "The endpoint ID to provision the add-on for (optional)")
-	rpcCmd.PersistentFlags().StringP("endpoint-url", "l", "https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The endpoint URL to provision the add-on for (optional - defaults to an ethereum mainnet endpoint")
-	rpcCmd.PersistentFlags().StringP("wss-url", "w", "wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The WSS URL to provision the add-on for (optional - defaults to an ethereum mainnet endpoint")
-	rpcCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain to provision the add-on for")
-	rpcCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network to provision the add-on for")
-	rpcCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan to provision the add-on for")
-	rpcCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The ID of the add-on to provision")
-	rpcCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The slug of the add-on to provision")
-
+	rpcCmd.PersistentFlags().StringP("url", "u", "", "The URL of the add-on's provision endpoint (optional, enables provisioning mode)")
+	rpcCmd.PersistentFlags().String("basic-auth", "QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "The basic auth credentials for the add-on")
+	rpcCmd.PersistentFlags().StringP("quicknode-id", "q", uuid.NewV4().String(), "The QuickNode ID (optional)")
+	rpcCmd.PersistentFlags().StringP("endpoint-id", "e", uuid.NewV4().String(), "The endpoint ID (optional)")
+	rpcCmd.PersistentFlags().StringP("endpoint-url", "l", "https://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The endpoint HTTP URL (optional)")
+	rpcCmd.PersistentFlags().StringP("wss-url", "w", "wss://long-late-firefly.quiknode.pro/4bb1e6b2dec8294938b6fdfdb7cf0cf70c4e97a2/", "The endpoint WSS URL (optional)")
+	rpcCmd.PersistentFlags().StringP("chain", "c", "ethereum", "The chain")
+	rpcCmd.PersistentFlags().StringP("network", "n", "mainnet", "The network")
+	rpcCmd.PersistentFlags().StringP("plan", "p", "discover", "The plan slug")
+	rpcCmd.PersistentFlags().StringP("add-on-id", "i", "33", "The add-on ID")
+	rpcCmd.PersistentFlags().StringP("add-on-slug", "s", "myslug", "The add-on slug")
 	rpcCmd.PersistentFlags().String("rpc-url", "", "The URL to make the RPC calls to")
 	rpcCmd.PersistentFlags().String("rpc-method", "", "The RPC Method to call")
-	rpcCmd.PersistentFlags().String("rpc-params", "", "The RPC Params to call the RPC Method with in JSON format")
+	rpcCmd.PersistentFlags().String("rpc-params", "", "The RPC params in JSON format")
+	rpcCmd.PersistentFlags().StringArray("header", []string{}, "HTTP header in \"Key: Value\" format (repeatable, enables header auth mode)")
 }

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -129,7 +129,7 @@ var rpcCmd = &cobra.Command{
 		httpReq.Header.Set("X-INSTANCE-ID", endpointID)
 		httpReq.Header.Set("X-QN-CHAIN", cmd.Flag("chain").Value.String())
 		httpReq.Header.Set("X-QN-NETWORK", cmd.Flag("network").Value.String())
-		httpReq.Header.Add("X-QN-TESTING", "true")
+		httpReq.Header.Set("X-QN-TESTING", "true")
 
 		client := http.Client{}
 		resp, err := client.Do(httpReq)


### PR DESCRIPTION
https://linear.app/quicknode/issue/DX-5324/improve-our-internal-monitoring-and-telemetrics-for-blockbook-and

## Summary

- Adds four implicit auth modes to `rpc` and `rest` commands: provisioning (existing behavior), header auth, basic auth, and no auth
- Mode is detected from which flags are provided — no explicit `--auth-type` flag needed
- New `--header` flag (repeatable) on `rpc` and `rest` forwards custom HTTP headers to the downstream call, skipping the provisioning step
- `--url` is now optional on both commands; omitting it skips provisioning
- Extracts shared `detectAuthMode`, `parseHeaders`, `applyAuthHeaders` helpers into `cmd/headers.go` with 16 unit tests
- Context headers (`X-QUICKNODE-ID`, `X-INSTANCE-ID`, etc.) always take precedence over user-supplied `--header` values
- Warns when `--header` is provided alongside `--url` (ignored in provisioning mode)

## Auth mode selection

| Mode | Trigger |
|------|---------|
| Provisioning | `--url` is provided |
| Header auth | `--header` is provided |
| Basic auth | `--basic-auth` explicitly set (no `--url`) |
| No auth | None of the above |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/... -v` passes (16 tests)
- [ ] Manual: `rpc --rpc-url=... --rpc-method=... --header "X-API-Key: secret"` — forwards header, skips provision
- [x] Manual: `rpc --rpc-url=... --rpc-method=... --basic-auth <b64>` — sends Authorization header, skips provision
- [ ] Manual: `rpc --rpc-url=... --rpc-method=...` — no auth header
- [ ] Manual: `rpc --url=... --rpc-url=... --rpc-method=... --header "X-Key: v"` — provisioning mode, warns that `--header` is ignored
- [ ] Same four cases for `rest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the marketplace CLI’s local test commands; behavior stays backward-compatible when `--url` is still used, with modest request-header logic covered by unit tests.
> 
> **Overview**
> **`rpc` and `rest` no longer require `--url`.** Provisioning runs only when `--url` is set; otherwise you can hit `--rpc-url` / `--rest-url` directly with optional auth.
> 
> Both commands now pick an **implicit auth mode** from flags (no `--auth-type`): provisioning (`--url`), custom **repeatable `--header`** (skips provision), **basic auth** when `--basic-auth` is explicitly set without `--url`, or **no auth**. Shared logic lives in new **`cmd/headers.go`** (`detectAuthMode`, `parseHeaders`, `applyAuthHeaders`), with unit tests in **`headers_test.go`**. Malformed `--header` values warn and are skipped; combining `--header` with `--url` warns that headers are ignored on the downstream call.
> 
> Auth headers are applied before the existing QuickNode context headers (`X-QUICKNODE-ID`, etc.), so those context values still override colliding user headers. **README** adds an auth-mode table and example invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9a99290b75ddefc153e9a27383ae1eaf3afdd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->